### PR TITLE
Fixed Python3_EXEUTABLE variable

### DIFF
--- a/server/scripting/CMakeLists.txt
+++ b/server/scripting/CMakeLists.txt
@@ -3,6 +3,8 @@
 # ============================
 
 
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
 # Some definitions
 set(SETUP_PY_IN ${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in)
 set(SETUP_PY    ${CMAKE_CURRENT_BINARY_DIR}/setup.py)


### PR DESCRIPTION
This PR resolves the building problem on Linux described in #1. CMake script relies on `Python3_EXECUTABLE` variable that is not set because `find_package` is not present. Execution of `./setup.py` fails because script has no executable permissions.