### PR TITLE
Add an INTERFACE library for palanteer.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,9 @@ find_package(Threads REQUIRED)
 #  * Python developer who does not plan to script: the viewer and the python instrumentation package
 #  * Python developer who wants to script only   : the python scripting package and the python instrumentation package
 
+# Build libpalanteer
+add_subdirectory(c++)
+
 # Build the viewer
 add_subdirectory(server/viewer)
 

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Requires C++11 or above
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+
+add_library(libpalanteer INTERFACE)
+target_include_directories(libpalanteer INTERFACE ./)

--- a/c++/testprogram/CMakeLists.txt
+++ b/c++/testprogram/CMakeLists.txt
@@ -50,8 +50,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CUSTOM_FLAGS}")
 # Test program executable
 # =======================
 add_executable            ("testprogram"                    testProgram.cpp testPart.cpp testPart.h)
-target_link_libraries     ("testprogram" ${STACKTRACE_LIBS} Threads::Threads)
-target_include_directories("testprogram" PRIVATE            ../../c++)
+target_link_libraries     ("testprogram" ${STACKTRACE_LIBS} Threads::Threads libpalanteer)
+
 if(NOT CUSTOM_FLAGS MATCHES ".*USE_PL=0.*")
   target_compile_options    ("testprogram" PRIVATE            -DUSE_PL=1)
 endif()
@@ -59,6 +59,6 @@ endif()
 # Test program executable with deactivated Palanteer
 # =======================
 add_executable            ("testprogram_disabled"                    testProgram.cpp testPart.cpp testPart.h)
-target_link_libraries     ("testprogram_disabled" ${STACKTRACE_LIBS} Threads::Threads)
+target_link_libraries     ("testprogram_disabled" ${STACKTRACE_LIBS} Threads::Threads libpalanteer)
 target_include_directories("testprogram_disabled" PRIVATE            ../../c++)
 

--- a/server/viewer/CMakeLists.txt
+++ b/server/viewer/CMakeLists.txt
@@ -73,16 +73,15 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CUSTOM_FLAGS}")
 # ==============
 file(GLOB_RECURSE ZSTD_SRC  CONFIGURE_DEPENDS  ../external/zstd/*.c ../external/zstd/*.h)
 file(GLOB         IMGUI_SRC CONFIGURE_DEPENDS  ../external/imgui/*.cpp ../external/imgui/*.h)
-file(GLOB         PALANTEER_INSTRU_SRC         ../../c++/palanteer.h)
 file(GLOB         BASE_SRC   CONFIGURE_DEPENDS ../base/*.cpp ../base/*.h)
 file(GLOB         COMMON_SRC CONFIGURE_DEPENDS ../common/*.cpp ../common/*.h)
 file(GLOB         VIEWER_SRC CONFIGURE_DEPENDS ../external/*.h *.cpp *.h)
-set(VIEWER_SRC ${PALANTEER_INSTRU_SRC} ${VIEWER_SRC} ${COMMON_SRC} ${BASE_SRC} ${ZSTD_SRC} ${IMGUI_SRC})
+set(VIEWER_SRC ${VIEWER_SRC} ${COMMON_SRC} ${BASE_SRC} ${ZSTD_SRC} ${IMGUI_SRC})
 
 # Viewer executable
 # =================
 add_executable("palanteer" ${WIN_MAIN} ${VIEWER_SRC})
-target_link_libraries("palanteer" ${PALANTEER_LIBS} Threads::Threads)
+target_link_libraries("palanteer" ${PALANTEER_LIBS} Threads::Threads libpalanteer)
 target_include_directories("palanteer" PRIVATE
   ../external/zstd ../external/zstd/common ../external/zstd/compress ../external/zstd/decompress
   ../external/imgui ../external ../../c++  ../base ../common)


### PR DESCRIPTION
So consumers of the c++ instrumentation can easily get the include folder added, just by doing `target_link_libraries()`. CMake will automagically add the include directories.